### PR TITLE
About Readme.md OPTION

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@ $ go get github.com/tSU-RooT/twatchmc　　
 MINECRAFT_JAR_FILE: minecraft_server.1.7.9.jar # 例
 SERVER_NAME: MyMineCraftServer
 SHOW_DWELLTIME: true # プレイヤーの滞在時間を日付の変わり目に表示する
-OPTION: [-Xmx8128M, -Xms8128M] # JVMへのオプションの指定(各オプションは,[カンマ]で区切る)
+OPTION: [-Xmx8128M -Xms8128M] # JVMへのオプションの指定
 ````
 ## How to use　　
 1.write twatchmc.yml  

--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@ $ go get github.com/tSU-RooT/twatchmc　　
 MINECRAFT_JAR_FILE: minecraft_server.1.7.9.jar # 例
 SERVER_NAME: MyMineCraftServer
 SHOW_DWELLTIME: true # プレイヤーの滞在時間を日付の変わり目に表示する
-OPTION: [-Xmx8128M -Xms8128M] # JVMへのオプションの指定
+OPTION: [-Xmx8128M, -Xms8128M] # JVMへのオプションの指定(各オプションは,[カンマ]で区切る)
 ````
 ## How to use　　
 1.write twatchmc.yml  


### PR DESCRIPTION
# 概要

これはReadmeの説明を加筆修正するものである。
また製作者にReadmeの記述を再度確認することを求めるrequestである。
## 詳細

前提として以下のコマンドによって起動が可能なことを確認済みである。

`java -jar -Xmx4096M -Xms4096M minecraftforge-universal-1.6.4-9.11.1.1345.jar nogui`

自分のサーバにおいてtwatchmcをOPTION指定の説明を参考に以下のようなtwatchmc.yml作成した。

``` Go:twatch.yml
MINECRAFT_JAR_FILE: minecraftforge-universal-1.6.4-9.11.1.1345.jar
SERVER_NAME: forge1.6.4
SHOW_DWELLTIME: true
OPTION: [-Xmx4096M -Xms4096M]
```

しかし、`twatchmc`コマンドを叩いて実行したところ以下のエラーが表示された。

> Invalid maximum heap size: -Xmx4096M -Xms4096M
> The specified size exceeds the maximum representable size
> Error: could not create the java Virtual Machine
> Error: A fatal exception has occurred. Program will exit.

これはオプションを,[カンマ]で区切ることで解決した。

``` Go:twatch.yml
〜
OPTION: [-Xmx4096M, -Xms4096M]
```

あくまでこれにより"エラーを回避した"だけだが、OPTIONの記述方法を再度確認して欲しい。
